### PR TITLE
Remove defunct choice of sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
 github: [ericwb]
-open_collective: bandit-sast


### PR DESCRIPTION
Bandit no longer is part of open collective so it should be removed here.