### PR TITLE
Set the same sponsor choices as Bandit

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,3 @@
+custom: ["https://psfmember.org/civicrm/contribute/transact/?reset=1&id=42"]
 github: [ericwb]
+tidelift: pypi/bandit


### PR DESCRIPTION
Bandit supports PSF, GitHub, and Tidelift. Bandit-action should be the same.