### PR TITLE
Bump Python version to 3.9

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,10 +70,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Bandit
       shell: bash


### PR DESCRIPTION
The minimum version of Python to use with Bandit is now 3.9. This is a result of Python 3.8 being end-of-life.