### PR TITLE
Pip install sarif and toml extras

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - name: Install Bandit
       shell: bash
-      run: pip install bandit[sarif]
+      run: pip install bandit[sarif,toml]
 
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
The bandit-action should install all extras for best compatiblity for users of the action. This change adds the toml extra. The only other extra missing is baseline, but that isn't exploited as part of the action yet.

Fixes #15