### PR TITLE
Add support for changing python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
 
 | Name | Description | Required | Default Value |
 |--|--|--|--|
+| python-version | Version of Python to use | False | `"3.9"` |
 | configfile | Config file to use for selecting plugins and overriding defaults | False | `"DEFAULT"` |
 | profile | Profile to use (defaults to executing all tests) | False | `"DEFAULT"` |
 | tests | Comma-separated list of test IDs to run | False | `"DEFAULT"` |

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,11 @@ branding:
   color: 'black'
 
 inputs: 
+  python-version:
+    description: |
+      Version of Python to use
+    required: false
+    default: '3.9'
   configfile:
     description: |
       Optional config file to use for selecting plugins and overriding defaults
@@ -70,10 +75,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Python 3.9
+    - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: ${{ inputs.python-version }}
 
     - name: Install Bandit
       shell: bash


### PR DESCRIPTION
Add support for modifying the default Python version (3.9) used by the action. The default ensures that no existing pipelines are affected (as far as I can tell...).