### PR TITLE
Pin nested action dependencies to full SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -85,7 +85,7 @@ runs:
       run: pip install bandit[sarif,toml]
 
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Run Bandit
       shell: bash
@@ -144,6 +144,6 @@ runs:
         INPUT_TARGETS: ${{ inputs.targets }}
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v4.37.8
+      uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       with:
         sarif_file: results.sarif


### PR DESCRIPTION
Full-SHA policies inspect nested action references too, so pinning `PyCQA/bandit-action` itself isn't enough. This patch replaces the three mutable tags in `action.yml` with the exact commits currently behind them:

- `actions/setup-python@v7` → `5fda3b95a4ea91299a34e894583c3862153e4b97`
- `actions/checkout@v7` → `3d3c42e5aac5ba805825da76410c181273ba90b1`
- `github/codeql-action/upload-sarif@v4.37.8` → `db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28`

The version comments stay beside each SHA, so the file remains readable and dependency updates remain straightforward. No action version or runtime behaviour is intentionally changed; the current versions are simply made immutable.

I verified the tag mappings against each official GitHub repository, parsed `action.yml`, checked that every nested `uses:` reference is a 40-character SHA, and ran `git diff --check`.

I'm contributing this from NOQT as a focused upstream security-hardening fix. Addresses #28.
